### PR TITLE
Fix frame dropout

### DIFF
--- a/pose_format/pose.py
+++ b/pose_format/pose.py
@@ -47,9 +47,11 @@ class Pose:
         dimensions = (maxs - mins).tolist()
         self.header.dimensions = PoseHeaderDimensions(*dimensions)
 
-    def normalize(self, info: PoseNormalizationInfo, scale_factor: float = 1):
+    def normalize(self, info: PoseNormalizationInfo, scale_factor: float = 1) -> "Pose":
         """
-        Normalize the point to a fixed distance between two points
+        Normalize the points to a fixed distance between two particular points.
+
+        TODO: This code will fail if the mean distance between the points is zero.
         """
         transposed = self.body.points_perspective()
 
@@ -63,13 +65,10 @@ class Pose:
 
         mean_distance = distance_batch(p1s, p2s).mean()
 
-        if mean_distance == 0.0:
-            scale = scale_factor
-        else:
-            scale = scale_factor / mean_distance  # scale all points to dist/scale
+        # scale all points to dist/scale
+        scale = scale_factor / mean_distance
 
-        if round(scale, 5) != 1:  # scale in numpy is often 0.99999..., presumably because of over-precision
-            self.body.data = self.body.data * scale
+        self.body.data = self.body.data * scale
 
         return self
 

--- a/pose_format/pose.py
+++ b/pose_format/pose.py
@@ -1,5 +1,5 @@
 from itertools import chain
-from typing import List, BinaryIO, Dict, Type
+from typing import List, BinaryIO, Dict, Type, Tuple
 
 import numpy as np
 import numpy.ma as ma
@@ -84,8 +84,16 @@ class Pose:
     def unnormalize_distribution(self, mu, std):
         self.body.data = (self.body.data * std) + mu
 
-    def frame_dropout(self, dropout_std=0.1):
-        body, selected_indexes = self.body.frame_dropout(dropout_std=dropout_std)
+    def frame_dropout_uniform(self,
+                             dropout_min: float = 0.2,
+                             dropout_max: float = 1.0) -> Tuple["Pose", List[int]]:
+        body, selected_indexes = self.body.frame_dropout_uniform(dropout_min=dropout_min, dropout_max=dropout_max)
+        return Pose(header=self.header, body=body), selected_indexes
+
+    def frame_dropout_normal(self,
+                             dropout_mean: float = 0.5,
+                             dropout_std: float = 0.1) -> Tuple["Pose", List[int]]:
+        body, selected_indexes = self.body.frame_dropout_normal(dropout_mean=dropout_mean, dropout_std=dropout_std)
         return Pose(header=self.header, body=body), selected_indexes
 
     def get_components(self, components: List[str], points: Dict[str, List[str]] = None):

--- a/pose_format/pose_test.py
+++ b/pose_format/pose_test.py
@@ -177,9 +177,11 @@ class TestPose(TestCase):
     def test_pose_object_should_be_callable(self):
         assert callable(Pose)
 
-    def test_pose_tf_posebody_normalize_eager_mode(self):
+    def test_pose_tf_posebody_normalize_eager_mode_preserves_shape(self):
 
         pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+
+        shape_before = pose.body.data.tensor.shape
 
         # in the mock data header components are named 0, 1, and so on
         # individual points are named 0_a, 0_b, and so on
@@ -187,6 +189,10 @@ class TestPose(TestCase):
             p1=("0", "0_a"),
             p2=("0", "0_b")
         ))
+
+        shape_after = pose.body.data.tensor.shape
+
+        self.assertEqual(shape_before, shape_after, "Normalize did not preserve tensor shape.")
 
     def test_pose_tf_posebody_frame_dropout_normal_eager_mode_num_frames_not_zero(self):
 
@@ -210,9 +216,11 @@ class TestPose(TestCase):
 
     # below: numpy pose body tests
 
-    def test_pose_numpy_posebody_normalize(self):
+    def test_pose_numpy_posebody_normalize_preserves_shape(self):
 
         pose = _get_random_pose_object_with_numpy_posebody(num_keypoints=5, frames_min=3)
+
+        shape_before = pose.body.data.shape
 
         # in the mock data header components are named 0, 1, and so on
         # individual points are named 0_a, 0_b, and so on
@@ -220,6 +228,10 @@ class TestPose(TestCase):
             p1=("0", "0_a"),
             p2=("0", "0_b")
         ))
+
+        shape_after = pose.body.data.shape
+
+        self.assertEqual(shape_before, shape_after, "Normalize did not preserve tensor shape.")
 
     def test_pose_numpy_posebody_frame_dropout_normal_eager_mode_num_frames_not_zero(self):
 

--- a/pose_format/pose_test.py
+++ b/pose_format/pose_test.py
@@ -240,3 +240,72 @@ class TestPose(TestCase):
         num_frames = pose_after_dropout.body.data.shape[0]
 
         self.assertNotEqual(num_frames, 0, "Number of frames after dropout can never be 0.")
+
+    # test if pose object methods can be used as tf.data.Dataset operations
+
+    def test_pose_normalize_can_be_used_in_tf_dataset_map(self):
+
+        num_examples = 10
+
+        dataset = tf.data.Dataset.range(num_examples)
+
+        def create_and_normalize_pose(example: tf.Tensor) -> tf.Tensor:
+
+            pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+
+            _ = pose.normalize(pose.header.normalization_info(
+                p1=("0", "0_a"),
+                p2=("0", "0_b")
+            ))
+
+            return example
+
+        dataset.map(create_and_normalize_pose)
+
+    def test_pose_normalize_distribution_can_be_used_in_tf_dataset_map(self):
+
+        num_examples = 10
+
+        dataset = tf.data.Dataset.range(num_examples)
+
+        def create_pose_and_normalize_distribution(example: tf.Tensor) -> tf.Tensor:
+
+            pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+
+            _ = pose.normalize_distribution(axis=(0, 1))
+
+            return example
+
+        dataset.map(create_pose_and_normalize_distribution)
+
+    def test_pose_frame_dropout_normal_can_be_used_in_tf_dataset_map(self):
+
+        num_examples = 10
+
+        dataset = tf.data.Dataset.range(num_examples)
+
+        def create_pose_and_frame_dropout_normal(example: tf.Tensor) -> tf.Tensor:
+
+            pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+
+            _, _ = pose.frame_dropout_normal()
+
+            return example
+
+        dataset.map(create_pose_and_frame_dropout_normal)
+
+    def test_pose_frame_dropout_uniform_can_be_used_in_tf_dataset_map(self):
+
+        num_examples = 10
+
+        dataset = tf.data.Dataset.range(num_examples)
+
+        def create_pose_and_frame_dropout_uniform(example: tf.Tensor) -> tf.Tensor:
+
+            pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+
+            _, _ = pose.frame_dropout_uniform()
+
+            return example
+
+        dataset.map(create_pose_and_frame_dropout_uniform)

--- a/pose_format/pose_tf_graph_mode_test.py
+++ b/pose_format/pose_tf_graph_mode_test.py
@@ -7,9 +7,11 @@ from pose_format.pose_test import _get_random_pose_object_with_tf_posebody
 
 class TestPose(TestCase):
 
-    def test_pose_tf_posebody_normalize_graph_mode(self):
+    def test_pose_tf_posebody_normalize_graph_mode_does_not_fail(self):
 
         with tf.Graph().as_default():
+
+            assert tf.executing_eagerly() is False
 
             pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
 
@@ -19,3 +21,21 @@ class TestPose(TestCase):
                 p1=("0", "0_a"),
                 p2=("0", "0_b")
             ))
+
+    def test_pose_tf_posebody_frame_dropout_uniform_graph_mode_does_not_fail(self):
+
+        with tf.Graph().as_default():
+
+            assert tf.executing_eagerly() is False
+
+            pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+            pose.frame_dropout_uniform()
+
+    def test_pose_tf_posebody_frame_dropout_normal_graph_mode_does_not_fail(self):
+
+        with tf.Graph().as_default():
+
+            assert tf.executing_eagerly() is False
+
+            pose = _get_random_pose_object_with_tf_posebody(num_keypoints=5)
+            pose.frame_dropout_normal()

--- a/pose_format/tensorflow/masked/tensor.py
+++ b/pose_format/tensorflow/masked/tensor.py
@@ -11,8 +11,7 @@ class MaskedTensor:
     def __getattr__(self, item):
         val = self.tensor.__getattribute__(item)
         if hasattr(val, '__call__'):  # If is a function
-            # return getattr(MaskedTorch, item)(self)
-            raise NotImplementedError("callbable '%s' not defined" % item)
+            raise NotImplementedError("callable '%s' not defined" % item)
         else:
             return val
 

--- a/pose_format/tensorflow/masked/tensor_graph_mode_test.py
+++ b/pose_format/tensorflow/masked/tensor_graph_mode_test.py
@@ -13,6 +13,8 @@ class TestMaskedTensor(TestCase):
 
         with tf.Graph().as_default():
 
+            assert tf.executing_eagerly() is False
+
             input_shape = (1,)
 
             tensor, mask = create_random_numpy_tensor_and_mask(shape=input_shape, probability_for_masked=0.1)
@@ -21,3 +23,17 @@ class TestMaskedTensor(TestCase):
 
             with self.assertRaises(TypeError):
                 float(masked_tf)
+
+    def test_eq_graph_execution(self):
+
+        with tf.Graph().as_default():
+
+            assert tf.executing_eagerly() is False
+
+            input_shape = (7, 6)
+
+            tensor, mask = create_random_numpy_tensor_and_mask(shape=input_shape, probability_for_masked=0.1)
+
+            masked_tf = MaskedTensor(tensor=tf.constant(tensor), mask=tf.constant(mask))
+
+            _ = masked_tf == 6.0

--- a/pose_format/tensorflow/pose_body.py
+++ b/pose_format/tensorflow/pose_body.py
@@ -33,6 +33,14 @@ class TensorflowPoseBody(PoseBody):
         return self.__class__(fps=self.fps, data=data, confidence=confidence)
 
     def frame_dropout_given_percent(self, dropout_percent: float):
+        """
+        Remove some frames from the data at random.
+
+        TODO: The code does not return the correct result if the input data has only one frame.
+
+        :param dropout_percent:
+        :return:
+        """
 
         data_len = tf.cast(tf.shape(self.data.tensor)[0], dtype=tf.float32)
 
@@ -44,9 +52,6 @@ class TensorflowPoseBody(PoseBody):
         number_sample = tf.cast(number_sample, dtype=tf.int32)
 
         idxs = tf.range(data_len - 1, dtype=tf.int32)
-
-        if data_len == 0.0:
-            return self.select_frames(idxs), idxs
 
         select_indexes = tf.sort(tf.random.shuffle(idxs)[:number_sample])
         select_indexes = tf.cast(select_indexes, dtype=tf.int32)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ print(packages)
 setup(
   name='pose_format',
   packages=packages,
-  version='0.0.8',
+  version='0.0.9',
   description='Library for viewing, augmenting, and handling .pose files',
   author='Amit Moryossef',
   author_email='amitmoryossef@gmail.com',


### PR DESCRIPTION
- Fixes statements in `pose.normalize `and `pose.frame_dropout`
- frame dropout in numpy and tf had different behaviours. I solved this by creating two versions of frame dropout: uniform or normal distribution
- adds new tests to test methods of the pose objects in the context of `tf.data.Dataset` mappings

Reason: Even though all test are passing and I specifically wrote tests for pose objects with tf posebody running in graph mode, I still ran into problems when using the methods while constructing a `tf.data.Dataset `object.