### PR TITLE
maximize video compatibility

### DIFF
--- a/pose_format/pose_visualizer.py
+++ b/pose_format/pose_visualizer.py
@@ -138,9 +138,9 @@ class PoseVisualizer:
 
         output_params = {
             "-vcodec": "libx264",
-            "-crf": 0,
             "-preset": "fast",
-            "-input_framerate": self.pose.body.fps
+            "-input_framerate": self.pose.body.fps,
+            "-pix_fmt": "yuv420p",
         }
 
         # Define writer with defined parameters and suitable output filename for e.g. `Output.mp4`


### PR DESCRIPTION
There is an issue to open videos generated by Mac QuickTime Player. To fix this compatibility issue:

- use default `-crf` option
- set `-pix_fmt` to `"yuv420p"`