### PR TITLE
Support GIF generation in the PoseVisualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ p.interpolate_fps(24, kind='cubic')
 p.interpolate_fps(24, kind='linear')
 ```
 
+### Visualization
+
+Visualize an existing pose file:
+
+```python
+from pose_format import Pose
+from pose_format.pose_visualizer import PoseVisualizer
+
+with open("example.pose", "rb") as f:
+    p = Pose.read(f.read())
+
+v = PoseVisualizer(p)
+
+v.save_video("example.mp4", v.draw())
+```
+
+Draw pose on top of video:
+
+```python
+v.save_video("example.mp4", v.draw_on_video("background_video_path.mp4"))
+```
+
+Convert pose to gif to easily inspect the result in Colab:
+
+```python
+# in a Colab notebook
+
+from IPython.display import Image
+
+v.save_gif("test.gif", v.draw())
+
+display(Image(open('test.gif','rb').read()))
+```
+
 ### Loading OpenPose data
 
 To load an OpenPose `directory`, use the `load_openpose_directory` utility:

--- a/pose_format/pose_visualizer.py
+++ b/pose_format/pose_visualizer.py
@@ -1,7 +1,7 @@
 import itertools
 import math
 from functools import lru_cache
-from typing import Tuple, Iterator
+from typing import Tuple, Iterable
 
 import numpy as np
 import numpy.ma as ma
@@ -126,7 +126,19 @@ class PoseVisualizer:
     def save_frame(self, f_name: str, frame: np.ndarray):
         self.cv2.imwrite(f_name, frame)
 
-    def save_video(self, f_name: str, frames: Iterator, custom_ffmpeg=None):
+    def save_gif(self, f_name: str, frames: Iterable[np.ndarray]):
+        try:
+            from PIL import Image
+        except ImportError:
+            raise ImportError(
+                "Please install Pillow with: pip install Pillow"
+            )
+
+        images = [Image.fromarray(self.cv2.cvtColor(frame, self.cv2.COLOR_BGR2RGB)) for frame in frames]
+        images[0].save(f_name, format="GIF", append_images=images,
+                       save_all=True, duration=1000 / self.pose.body.fps, loop=0)
+
+    def save_video(self, f_name: str, frames: Iterable[np.ndarray], custom_ffmpeg=None):
         try:
             from vidgear.gears import WriteGear
         except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ print(packages)
 setup(
   name='pose_format',
   packages=packages,
-  version='0.1.1',
+  version='0.1.2',
   description='Library for viewing, augmenting, and handling .pose files',
   author='Amit Moryossef',
   author_email='amitmoryossef@gmail.com',


### PR DESCRIPTION
It's more complicated to show videos in Google Colab than GIFs, so I added support

```python
from IPython.display import Image
display(Image(open('test.gif','rb').read()))
```

![test_256](https://user-images.githubusercontent.com/5757359/188333284-b6e2b800-1d6c-4cb1-a562-3905f1740779.gif)
