### PR TITLE
feat(visualizer): add fast drawing function

### DIFF
--- a/pose_format/pose_visualizer.py
+++ b/pose_format/pose_visualizer.py
@@ -33,7 +33,7 @@ class PoseVisualizer:
 
         for person, person_confidence in zip(frame, frame_confidence):
             c = person_confidence.tolist()
-            points_2d = [tuple(p[:2]) for p in person.tolist()]
+            points_2d = [tuple(p) for p in person[:, :2].tolist()]
             idx = 0
             for component in self.pose.header.components:
                 colors = [np.array(c[::-1]) for c in component.colors]
@@ -150,18 +150,19 @@ class FastAndUglyPoseVisualizer(PoseVisualizer):
     """
 
     def _draw_frame(self, frame: ma.MaskedArray, img, color: int):
+        ignored_point = (0, 0)
         # Note: this can be made faster by drawing polylines instead of lines
         thickness = 1
         for person in frame:
-            points_2d = [tuple(p[:2]) for p in person.tolist()]
+            points_2d = [tuple(p) for p in person[:, :2].tolist()]
             idx = 0
             for component in self.pose.header.components:
                 for (p1, p2) in component.limbs:
                     point1 = points_2d[p1 + idx]
                     point2 = points_2d[p2 + idx]
-
-                    # Antialiasing is a bit slow, but necessary
-                    self.cv2.line(img, point1, point2, color, thickness, lineType=self.cv2.LINE_AA)
+                    if point1 != ignored_point and point2 != ignored_point:
+                        # Antialiasing is a bit slow, but necessary
+                        self.cv2.line(img, point1, point2, color, thickness, lineType=self.cv2.LINE_AA)
 
                 idx += len(component.points)
         return img

--- a/pose_format/pose_visualizer.py
+++ b/pose_format/pose_visualizer.py
@@ -145,6 +145,9 @@ class PoseVisualizer:
 
 
 class FastAndUglyPoseVisualizer(PoseVisualizer):
+    """
+    This class draws all frames as grayscale, without opacity based on confidence
+    """
 
     def _draw_frame(self, frame: ma.MaskedArray, img, color: int):
         # Note: this can be made faster by drawing polylines instead of lines
@@ -164,9 +167,6 @@ class FastAndUglyPoseVisualizer(PoseVisualizer):
         return img
 
     def draw(self, background_color: int = 0, foreground_color: int = 255):
-        """
-        This function draws all frames as grayscale, without confidence
-        """
         int_frames = np.array(np.around(self.pose.body.data.data), dtype="int32")
         background = np.full((self.pose.header.dimensions.height, self.pose.header.dimensions.width),
                              fill_value=background_color, dtype="uint8")

--- a/pose_format/pose_visualizer.py
+++ b/pose_format/pose_visualizer.py
@@ -24,6 +24,23 @@ class PoseVisualizer:
                 "Please install OpenCV with: pip install opencv-python"
             )
 
+    def _draw_frame_fast_and_ugly(self, frame: ma.MaskedArray, img, color: int):
+        # Note: this can be made faster by drawing polylines instead of lines
+        thickness = 1
+        for person in frame:
+            points_2d = [tuple(p[:2]) for p in person.tolist()]
+            idx = 0
+            for component in self.pose.header.components:
+                for (p1, p2) in component.limbs:
+                    point1 = points_2d[p1 + idx]
+                    point2 = points_2d[p2 + idx]
+
+                    # Antialiasing is a bit slow, but necessary
+                    self.cv2.line(img, point1, point2, color, thickness, lineType=self.cv2.LINE_AA)
+
+                idx += len(component.points)
+        return img
+
     def _draw_frame(self, frame: ma.MaskedArray, frame_confidence: np.ndarray, img) -> np.ndarray:
         background_color = img[0][0]  # Estimation of background color for opacity. `mean` is slow
 
@@ -33,6 +50,7 @@ class PoseVisualizer:
 
         for person, person_confidence in zip(frame, frame_confidence):
             c = person_confidence.tolist()
+            points_2d = [tuple(p[:2]) for p in person.tolist()]
             idx = 0
             for component in self.pose.header.components:
                 colors = [np.array(c[::-1]) for c in component.colors]
@@ -50,18 +68,17 @@ class PoseVisualizer:
                                         color=_point_color(i), thickness=-1, lineType=16)
 
                 if self.pose.header.is_bbox:
-                    point1 = tuple(person[0 + idx].tolist())
-                    point2 = tuple(person[1 + idx].tolist())
+                    point1 = points_2d[0 + idx]
+                    point2 = points_2d[1 + idx]
                     color = tuple(np.mean([_point_color(0), _point_color(1)], axis=0))
 
                     self.cv2.rectangle(img=img, pt1=point1, pt2=point2, color=color, thickness=thickness)
                 else:
-                    int_person = person.astype(np.int32)
                     # Draw Limbs
                     for (p1, p2) in component.limbs:
                         if c[p1 + idx] > 0 and c[p2 + idx] > 0:
-                            point1 = tuple(int_person[p1 + idx].tolist()[:2])
-                            point2 = tuple(int_person[p2 + idx].tolist()[:2])
+                            point1 = points_2d[p1 + idx]
+                            point2 = points_2d[p2 + idx]
 
                             # length = ((point1[0] - point2[0]) ** 2 + (point1[1] - point2[1]) ** 2) ** 0.5
 
@@ -69,24 +86,26 @@ class PoseVisualizer:
 
                             self.cv2.line(img, point1, point2, color, thickness, lineType=self.cv2.LINE_AA)
 
-                            # deg = math.degrees(math.atan2(point1[1] - point2[1], point1[0] - point2[0]))
-                            # polygon = cv2.ellipse2Poly(
-                            #   (int((point1[0] + point2[0]) / 2), int((point1[1] + point2[1]) / 2)),
-                            #   (int(length / 2), thickness),
-                            #   int(deg),
-                            #   0, 360, 1)
-                            # cv2.fillConvexPoly(img=img, points=polygon, color=color)
-
                 idx += len(component.points)
 
         return img
 
     def draw(self, background_color: Tuple[int, int, int] = (255, 255, 255), max_frames: int = None):
-        int_data = np.array(np.around(self.pose.body.data.data), dtype="int32")
+        int_frames = np.array(np.around(self.pose.body.data.data), dtype="int32")
         background = np.full((self.pose.header.dimensions.height, self.pose.header.dimensions.width, 3),
                              fill_value=background_color, dtype="uint8")
-        for frame, confidence in itertools.islice(zip(int_data, self.pose.body.confidence), max_frames):
+        for frame, confidence in itertools.islice(zip(int_frames, self.pose.body.confidence), max_frames):
             yield self._draw_frame(frame, confidence, img=background.copy())
+
+    def draw_fast_and_ugly(self, background_color: int=0, foreground_color:int=255):
+        """
+        This function draws all frames as grayscale, without confidence
+        """
+        int_frames = np.array(np.around(self.pose.body.data.data), dtype="int32")
+        background = np.full((self.pose.header.dimensions.height, self.pose.header.dimensions.width),
+                             fill_value=background_color, dtype="uint8")
+        for frame in int_frames:
+            yield self._draw_frame_fast_and_ugly(frame, img=background.copy(), color=foreground_color)
 
     def draw_on_video(self, background_video, max_frames: int = None, blur=False):
         int_data = np.array(np.around(self.pose.body.data.data), dtype="int32")


### PR DESCRIPTION
Added a new drawing utility function to draw poses faster than before.
Old method: 42 videos per second
New method: 726 videos per second
x17 faster

This drawing utility is meant more for the consumption of a neural network, rather than human eyes, as I would like to feed in a tensor `Nx64x64x4`

![download-1](https://user-images.githubusercontent.com/5757359/188336807-ed468647-9ff2-4c51-bc9f-b642dea591f5.gif) ![download](https://user-images.githubusercontent.com/5757359/188336809-68563180-ebbd-46ce-9f55-0614ffc04c1d.gif) ![download-3](https://user-images.githubusercontent.com/5757359/188336805-029f6d7a-7a18-4100-9eed-7c9f781a489b.gif) ![download-2](https://user-images.githubusercontent.com/5757359/188336804-3e583427-9f97-4657-8aba-f56437e4fd64.gif) 
(these were not generated with this exact method, i removed "confidence")